### PR TITLE
Using ubuntu:latest as Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM ubuntu:latest
 RUN apt-get update -qq && apt-get install -y build-essential libsqlite3-dev sqlite3 git cmake libboost-all-dev catch2 libfreetype-dev
 
 ENV ROOT=/opt/rdkitsqlite


### PR DESCRIPTION
Necessary for GitHub Actions to run in MCM repo. Adds about 200 MB to the image.