### PR TITLE
feature: function to extract descriptors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL=/bin/sh
 CC=gcc
 SRC=src/main.c src/utils.c
 CFLAGS=-g -fPIC -shared
-LDFLAGS=-I $(RDKIT)/Code -I $(RDKIT)/Code/MinimalLib -lrdkitcffi -lcjson -Llib
+LDFLAGS=-Wl,-Bstatic -lcjson -Wl,-Bdynamic -I $(RDKIT)/Code -I $(RDKIT)/Code/MinimalLib -lrdkitcffi -Llib
 OUTPUT=librdkitsqlite
 
 all: $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL=/bin/sh
 CC=gcc
 SRC=src/main.c src/utils.c
 CFLAGS=-g -fPIC -shared
-LDFLAGS=-I $(RDKIT)/Code -I $(RDKIT)/Code/MinimalLib -lrdkitcffi -Llib
+LDFLAGS=-I $(RDKIT)/Code -I $(RDKIT)/Code/MinimalLib -lrdkitcffi -lcjson -Llib
 OUTPUT=librdkitsqlite
 
 all: $(OUTPUT)

--- a/docker/lib/Dockerfile
+++ b/docker/lib/Dockerfile
@@ -7,6 +7,7 @@ ARG BOOST_PATCH_VERSION="0"
 ARG BOOST_DOT_VERSION="${BOOST_MAJOR_VERSION}.${BOOST_MINOR_VERSION}.${BOOST_PATCH_VERSION}"
 ARG BOOST_UNDERSCORE_VERSION="${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_${BOOST_PATCH_VERSION}"
 
+# Install Boost
 WORKDIR /opt
 RUN wget -q https://boostorg.jfrog.io/artifactory/main/release/${BOOST_DOT_VERSION}/source/boost_${BOOST_UNDERSCORE_VERSION}.tar.gz && \
   tar xzf boost_${BOOST_UNDERSCORE_VERSION}.tar.gz
@@ -18,6 +19,16 @@ ENV ROOT=/opt/rdkitsqlite
 WORKDIR $ROOT
 COPY . $ROOT
 
+# Install cJSON
+ENV CJSON_ROOT=/opt/cJSON
+RUN git clone https://github.com/DaveGamble/cJSON.git $CJSON_ROOT
+RUN mkdir -p $CJSON_ROOT/build
+WORKDIR $CJSON_ROOT/build
+RUN cmake .. -DBUILD_SHARED_LIBS=OFF
+RUN make
+RUN make install
+
+# Install RDKit
 ENV RDKIT_ROOT=$ROOT/rdkit
 RUN git clone https://github.com/rdkit/rdkit.git $RDKIT_ROOT
 RUN mkdir -p $RDKIT_ROOT/build
@@ -27,6 +38,7 @@ RUN make -j 2 cffi_test
 RUN Code/MinimalLib/cffi_test
 RUN mkdir -p $ROOT/lib && cp lib/* $ROOT/lib
 
+# Build library
 WORKDIR $ROOT
 RUN sed -i '/^LDFLAGS=/ s|$| -I/opt/boost/include|' Makefile
 RUN make

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "cffiwrapper.h"
+#include <cjson/cJSON.h>
 #include "sqlite3ext.h" /* Do not use <sqlite3.h>! */
 SQLITE_EXTENSION_INIT1
 
@@ -25,6 +26,24 @@ static void mol_substruct_func(
   sqlite3_result_int(context, match);
 }
 
+static void mol_descriptor_func(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  char *smiles = (char *)sqlite3_value_text(argv[0]);
+  char *key = (char *)sqlite3_value_text(argv[1]);
+  char *value;
+
+  int err = get_descriptor(smiles, key, &value);
+  if (err != 0) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  sqlite3_result_text(context, value, -1, SQLITE_TRANSIENT);
+}
+
 int sqlite3_rdkitsqlite_init(
   sqlite3 *db, 
   char **pzErrMsg, 
@@ -37,6 +56,10 @@ int sqlite3_rdkitsqlite_init(
   sqlite3_create_function(db, "substruct_match", 2,
                    SQLITE_UTF8|SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC,
                    0, mol_substruct_func, 0, 0);
+
+  sqlite3_create_function(db, "get_descriptor", 2,
+                   SQLITE_UTF8|SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC,
+                   0, mol_descriptor_func, 0, 0);
 
   if (rc != SQLITE_OK) {
     fprintf(stderr, "Error: %s\n", sqlite3_errmsg(db));

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,2 +1,3 @@
 int canon_smiles(char *smiles);
 int substruct_match(char *smiles, char *smarts, int *match);
+int get_descriptor(char *smiles, char *key, char **value);


### PR DESCRIPTION
Enabled access to RDKit molecule descriptors via a new `get_descriptor` function.